### PR TITLE
Properly serialize the certificate on disk

### DIFF
--- a/IefPolicies.psm1
+++ b/IefPolicies.psm1
@@ -810,7 +810,8 @@ function New-IefPoliciesCert {
             $pfxPath = ".\RESTClientCert.pfx"
             $cert | Export-PfxCertificate -FilePath $pfxPath -Password $pfxPwd
             $pkcs12=[Convert]::ToBase64String([System.IO.File]::ReadAllBytes((get-childitem -path $pfxPath).FullName))
-            $cert.PublicKey | Out-File -FilePath ".\ClientCert.cer"
+            $base64Cert = $([Convert]::ToBase64String($cert.Export('Cert'), [System.Base64FormattingOptions]::InsertLineBreaks))
+            Set-Content -Path ".\ClientCert.cer" -Value $base64Cert
             Write-Host "ClientCert.cer file created"
         } catch {
             Write-Error "Error creating/writing or reading the cert."


### PR DESCRIPTION
Not exactly sure what was the original intention in passing the `PublicKey` object to a file but judging from the file extension, I'm assuming we are attempting to export the Base64 encoded certificate.

Nevertheless, the current `main` with `$cert.PublicKey | Out-File -FilePath ".\ClientCert.cer"` produces a file as follows:

```text
[32;1mEncodedKeyValue                             EncodedParameters                           Key                                 Oid[0m
[32;1m---------------                             -----------------                           ---                                 ---[0m
System.Security.Cryptography.AsnEncodedData System.Security.Cryptography.AsnEncodedData System.Security.Cryptography.RSACng System.Security.Cryptography.Oid
```

This is obviously a bug and here's my attempt at fixing it.