### PR TITLE
Print the URL for the b2c verification if chrome can't be started

### DIFF
--- a/IefPolicies.psm1
+++ b/IefPolicies.psm1
@@ -407,6 +407,11 @@ function Connect-IEFPolicies {
         #if(-not (Get-Host).Name.StartsWith('Visual Studio Code Host')) {
         if(-not $env:TERM_PROGRAM -eq 'vscode') {        
             Start-Process "chrome.exe" $codeResp.verification_uri
+            
+            # If the previous command does not exit successfully, print the verification URL in the window for the user to manually navigate to. 
+            if (!$?) {
+                Write-Warning "Chrome is not installed on this machine. Please navigate to the following URL for verification: {0}" -f $codeResp.verification_uri
+            }
         }
 
         $uri = "https://login.microsoftonline.com/{0}/oauth2/v2.0/token" -f $script:tenantName


### PR DESCRIPTION
If Chrome cant be started for whatever reason (not installed, not running on windows, etc), the Connect-Iefpolicies function within this module will now print the verification URL and prompt the user to manually navigate to it. 