### PR TITLE
Encode policy files as UTF-8 for Graph upload

### DIFF
--- a/IefPolicies.psm1
+++ b/IefPolicies.psm1
@@ -120,7 +120,7 @@
                     $policyId = $p.Id.Replace('_1A_', '_1A_{0}' -f $prefix)
                 }
                 if (-not $generateOnly) {
-                    $resp = Invoke-WebRequest -UseBasicParsing  -Uri ("https://graph.microsoft.com/beta/trustFramework/policies/{0}/`$value" -f $policyId) -Method Put -Headers $headersXml -Body $policy -SkipHttpErrorCheck
+                    $resp = Invoke-WebRequest -UseBasicParsing  -Uri ("https://graph.microsoft.com/beta/trustFramework/policies/{0}/`$value" -f $policyId) -Method Put -Headers $headersXml -ContentType 'application/xml; charset=utf-8' -Body $policy -SkipHttpErrorCheck
                     if ($resp.StatusCode -eq 201) {
                         Write-Host "Created"
                     } elseif ($resp.StatusCode -eq 200) {
@@ -167,7 +167,6 @@
         'Authorization' = ("Bearer {0}" -f $script:tokens.access_token);
     }
     $headersXml = @{
-    'Content-Type' = 'application/xml';
     'Authorization' = ("Bearer {0}" -f $script:tokens.access_token);
     }
 
@@ -295,7 +294,6 @@ function Export-IEFPolicies {
         'Authorization' = ("Bearer {0}" -f $script:tokens.access_token);
     }
     $headersXml = @{
-        'Content-Type' = 'application/xml';
         'Authorization' = ("Bearer {0}" -f $script:tokens.access_token);
     }
     if (-not $destinationPath) {


### PR DESCRIPTION
For policy upload (HTTP PUT) request, moved content type declaration into Invoke-WebRequest's `-ContentType` parameter instead of as part of `-Headers`. Removed content type from policy download (HTTP GET) request, which doesn't send a body anyway.

_Impl. note_: I tried modifying the headers like this at first:

```powershell
$headersXml = @{
    'Content-Type' = 'application/xml; charset=utf-8';
    'Authorization' = ("Bearer {0}" -f $script:tokens.access_token);
}
```

but `Invoke-WebRequest` seems to ignore this. It was only after moving the content type setting to the `-ContentType` parameter that `Invoke-WebRequest` respected it.

_Additional note_: For Graph API endpoint [`GET /trustFramework/policies/{id}/$value`](https://docs.microsoft.com/en-us/graph/api/trustframeworkpolicy-get), it doesn't currently seem possible to request a response content type of `charset=utf-8`. Unfortunately this means all policy file output of `Export-IEFPolicies` will contain � characters instead of UTF-8 equivalents.