### PR TITLE
Added write-error to Debug-IEFPolicies

### DIFF
--- a/IefPolicies.psm1
+++ b/IefPolicies.psm1
@@ -1803,7 +1803,15 @@ function Debug-IEFPolicies {
     }
     CheckInheritedAttrs (New-Object Collections.Generic.List[String]) $script:policies.Root    
 
-    Write-Host ("Found {0} possible issues" -f $script:errorCount)
+    If ($script:errorCount -gt 0)
+    {
+        $InvalidOperationException = New-Object System.InvalidOperationException
+        Write-Error -Exception $InvalidOperationException -Message ("{0} possible issues found with policies." -f $script:errorCount) -ErrorAction Stop
+    }
+    Else
+    {
+        Write-Host ("Found {0} possible issues" -f $script:errorCount)
+    }
 }
 
 function ConvertTo-IefPolicies {


### PR DESCRIPTION
The text based output in Debug-IEFPolicies is difficult to work with. We plan to add step for running this function on the policy files before they can be merged to main. With this change we will easily be able to stop the merge if there are any errors detected in the policy files.